### PR TITLE
Add release pipelines

### DIFF
--- a/.github/workflows/pages-release.yml
+++ b/.github/workflows/pages-release.yml
@@ -1,0 +1,97 @@
+name: Deploy Botkube plugins to GitHub Pages
+
+on:
+  push:
+    tags:
+      - "*"
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Build plugins binaries
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          version: latest
+          args: build --rm-dist
+
+      - name: Generate plugins index.yaml
+        env:
+          PLUGIN_DOWNLOAD_URL_BASE_PATH: "https://${{github.repository_owner}}.github.io/${{ github.event.repository.name }}"
+        run: |
+          go run github.com/kubeshop/botkube/hack -binaries-path "./dist"
+      - name: Release description
+        env:
+          PLUGIN_DOWNLOAD_URL_BASE_PATH: "https://${{github.repository_owner}}.github.io/${{ github.event.repository.name }}"
+        run: |
+          cat << EOF > README.md
+
+          Botkube Plugins **${GITHUB_REF#refs/tags/}** version are now available! :rocket:
+
+          To use plugins from this release, configure Botkube with:
+          EOF
+          cat << 'EOF' >> README.md
+
+          ```yaml
+          plugins:
+            repositories:
+          EOF
+          cat << EOF >> README.md
+              ${{ github.event.repository.name }}: ${PLUGIN_DOWNLOAD_URL_BASE_PATH}/plugins-index.yaml
+          EOF
+          cat << 'EOF' >> README.md
+          ```
+          EOF
+
+      - name: Render Markdown
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /markdown \
+            -f text="$(cat ./README.md)" > index.html
+
+      - name: Publish GitHub release
+        run: |
+          mkdir public
+          mv dist/executor_* public/
+          mv dist/source_* public/
+          mv plugins-index.yaml public/
+          mv index.html public/
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: public
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Deploy Botkube plugins on GitHub Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          install-only: true
+          version: latest
+
+      - name: Build plugins and generate plugins index.yaml
+        env:
+          PLUGIN_DOWNLOAD_URL_BASE_PATH: "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}"
+        run: |
+          make build-plugins
+          make gen-plugin-index
+      - name: Release description
+        env:
+          PLUGIN_DOWNLOAD_URL_BASE_PATH: "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}"
+        run: |
+          cat << EOF > release.md
+
+          Botkube Plugins **${GITHUB_REF#refs/tags/}** version are now available! :rocket:
+
+          To use plugins from this release, configure Botkube with:
+          EOF
+          cat << 'EOF' >> release.md
+
+          ```yaml
+          plugins:
+            repositories:
+          EOF
+          cat << EOF >> release.md
+              ${{ github.event.repository.name }}: ${PLUGIN_DOWNLOAD_URL_BASE_PATH}/plugins-index.yaml
+          EOF
+          cat << 'EOF' >> release.md
+          ```
+          EOF
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF#refs/tags/}" \
+          --notes-file release.md \
+          ./dist/source_* \
+          ./dist/executor_* \
+          ./plugins-index.yaml

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,35 @@
+name: Testing
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  cancel-previous-workflows:
+    name: Cancel previous workflows
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    # https://github.com/styfle/cancel-workflow-action#advanced-token-permissions
+    permissions:
+      actions: write
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5
+        with:
+          access_token: ${{ github.token }}
+
+  code-quality-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v3
+      - name: "Set up Go"
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - name: "Check code quality"
+        uses: golangci/golangci-lint-action@v3

--- a/README.md
+++ b/README.md
@@ -5,7 +5,12 @@ This repository shows the example Botkube [source](https://docs.botkube.io/archi
 It is intended as a template repository to start developing Botkube plugins in Go. Repository contains:
 
 - The [`echo`](cmd/echo/main.go) executor that sends back the command that was specified,
-- The [`ticker`](cmd/ticker/main.go) source that emits an event at a specified interval,
+- The [`ticker`](cmd/ticker/main.go) source that emits an event each time the configured time duration elapses,
+- The release [GitHub Action](https://github.com/features/actions) jobs:
+	- that creates [GitHub release](.github/workflows/release.yml) with plugin binaries and index file each time a new tag is pushed.
+		- See: https://github.com/kubeshop/botkube-plugins-template/releases/latest
+	- that updates [GitHub Pages](.github/workflows/pages-release.yml) with plugin binaries and index file each time a new tag is pushed.
+		- See: https://kubeshop.github.io/botkube-plugins-template/
 
 To learn more, see the [tutorial on how to use this template repository](https://docs.botkube.io/plugin/template.md).
 


### PR DESCRIPTION
# Description

Merge after https://github.com/kubeshop/botkube-plugins-template/pull/2

- Add release pipelines

Tested on my repository:

GitHub release:
- https://github.com/mszostok/botkube-plugins-template/actions/runs/3920370189
- https://github.com/mszostok/botkube-plugins-template/releases/tag/v0.0.9
 
to test with Botkube:
```yaml
plugins:
  repositories:
    botkube-examples:
      url: https://github.com/mszostok/botkube-plugins-template/releases/download/v0.0.9/plugins-index.yaml

sources:
  'plugin-based':
    botkube-examples/ticker:
      enabled: true
      config:
        duration: 1s
executors:
  plugin-based:
    botkube-examples/echo:
      enabled: true
      config: { }
```
GitHub Pages:
- https://github.com/mszostok/botkube-plugins-template/actions/runs/3920370192
- https://mszostok.github.io/botkube-plugins-template/

```yaml
plugins:
  repositories:
    botkube-examples:
      url: https://mszostok.github.io/botkube-plugins-template/plugins-index.yaml

sources:
  'plugin-based':
    botkube-examples/ticker:
      enabled: true
      config:
        duration: 1s
executors:
  plugin-based:
    botkube-examples/echo:
      enabled: true
      config: { }
```